### PR TITLE
Implement left and right arrow key selection

### DIFF
--- a/BTRCollectionView/BTRCollectionView.m
+++ b/BTRCollectionView/BTRCollectionView.m
@@ -775,8 +775,10 @@ static NSString* const BTRCollectionViewViewKey = @"BTRCollectionViewViewKey";
 	BOOL moreThanOneSection = ([_collectionViewData numberOfSections] > 1);
 	NSUInteger section = ((firstSection & moreThanOneSection) ? [currentIndexPath indexAtPosition:0] - 1 : [currentIndexPath indexAtPosition:0]);
 	
-	NSUInteger newIndex = ([currentIndexPath indexAtPosition:1] - 1);
-	NSUInteger indexArr[] = {section, (newIndex != 0 ? newIndex : 0)};
+	NSUInteger newIndex = ([currentIndexPath indexAtPosition:1] != 0 ? [currentIndexPath indexAtPosition:1] - 1 : 0);
+	BOOL firstPossibleSelection = (newIndex == 0);
+
+	NSUInteger indexArr[] = {section, (firstPossibleSelection ? 0 : newIndex)};
 	NSIndexPath *newIndexPath = [NSIndexPath indexPathWithIndexes:indexArr length:2];
 	
 	BOOL sameItemSelected = ([currentIndexPath compare:firstIndexPath] == NSOrderedSame);


### PR DESCRIPTION
Partially solves #2.  Selection works like the finder:
- Hold shift and use the arrow keys to highlight subsequent cells
- When highlighting "goes past" the first or last selected row, cells
  after said row are de-selected.
- Using the left and right arrow keys unmodified de-selects all cells
  save the new one that is being selected.
- The user cannot select past the first or last item.

Known Bugs/Quirks:
- Not tested with multi-sectioned collection views.  Theoretically it should work, given the logic I put in to handle cross-section highlights, but the behavior may be unsatisfactory.
- Up and down keys are left unimplemented.  I felt a discussion of how up and down selection should work should be had before I continue.
